### PR TITLE
Allow services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Usage
 
 Creates a KMS Key for use with SNS.
@@ -39,6 +40,21 @@ This project constitutes a work of the United States Government and is not subje
 |------|---------|
 | aws | ~> 3.0 |
 
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_kms_alias.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -56,3 +72,4 @@ This project constitutes a work of the United States Government and is not subje
 | aws\_kms\_alias\_arn | The Amazon Resource Name (ARN) of the key alias. |
 | aws\_kms\_alias\_name | The display name of the alias. |
 | aws\_kms\_key\_arn | The Amazon Resource Name (ARN) of the key. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Usage
 
 Creates a KMS Key for use with SNS.
@@ -40,25 +39,11 @@ This project constitutes a work of the United States Government and is not subje
 |------|---------|
 | aws | ~> 3.0 |
 
-## Modules
-
-No Modules.
-
-## Resources
-
-| Name |
-|------|
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) |
-| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) |
-| [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| allow\_services | The list of services that will be allowed kms GenerateDataKey and Decrypt IAM permissions. | `list(string)` | <pre>[<br>  "cloudwatch.amazonaws.com",<br>  "events.amazonaws.com"<br>]</pre> | no |
 | description | n/a | `string` | `"A KMS key used to encrypt SNS messages at-rest."` | no |
 | key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. | `string` | `30` | no |
 | name | The display name of the alias. The name must start with the word "alias" followed by a forward slash (alias/). | `string` | `"alias/sns"` | no |
@@ -71,4 +56,3 @@ No Modules.
 | aws\_kms\_alias\_arn | The Amazon Resource Name (ARN) of the key alias. |
 | aws\_kms\_alias\_name | The display name of the alias. |
 | aws\_kms\_key\_arn | The Amazon Resource Name (ARN) of the key. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -59,36 +59,21 @@ data "aws_iam_policy_document" "sns" {
     }
     resources = ["*"]
   }
+
   statement {
-    sid = "Allow CloudWatch"
+    sid = "Allow Services to Decrypt"
     actions = [
       "kms:GenerateDataKey*",
       "kms:Decrypt"
     ]
     effect = "Allow"
     principals {
-      type = "Service"
-      identifiers = [
-        "cloudwatch.amazonaws.com"
-      ]
+      type        = "Service"
+      identifiers = var.allow_services
     }
     resources = ["*"]
   }
-  statement {
-    sid = "Allow CloudWatch Events"
-    actions = [
-      "kms:GenerateDataKey*",
-      "kms:Decrypt"
-    ]
-    effect = "Allow"
-    principals {
-      type = "Service"
-      identifiers = [
-        "events.amazonaws.com"
-      ]
-    }
-    resources = ["*"]
-  }
+
   statement {
     sid = "Allow SNS"
     actions = [
@@ -104,6 +89,7 @@ data "aws_iam_policy_document" "sns" {
     }
     resources = ["*"]
   }
+
 }
 
 resource "aws_kms_key" "sns" {

--- a/variables.tf
+++ b/variables.tf
@@ -23,3 +23,12 @@ variable "tags" {
     Automation = "Terraform"
   }
 }
+
+variable "allow_services" {
+  type        = list(string)
+  description = "The list of services that will be allowed kms GenerateDataKey and Decrypt IAM permissions."
+  default = [
+    "cloudwatch.amazonaws.com",
+    "events.amazonaws.com"
+  ]
+}


### PR DESCRIPTION
This PR adds the `allow_services` variable for configuring services that are granted kms access for cases where the default cloudwatch and events is not sufficient (e.g. costalerts).